### PR TITLE
🔧修复邮箱验证结果弹窗bug、跳转bug，⤴️显示视频海报帧

### DIFF
--- a/components/ContentFile.vue
+++ b/components/ContentFile.vue
@@ -22,7 +22,7 @@
         :height="videoHeight"
         aspectRatio="16:9"
         :fluid="true"
-        preload="none"
+        preload="metadata"
         :muted="false"
         :controls="true"
       >

--- a/pages/email-validate/_uuid/index.vue
+++ b/pages/email-validate/_uuid/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main-full-middle" v-loading="loading">
+  <div class="main-full-middle">
     <div style="width: 642px">
       <div v-if="!loading">
         <el-result
@@ -9,9 +9,7 @@
           subTitle="将在3秒后跳转到首页"
         >
           <template slot="extra">
-            <el-button type="primary" size="medium" @click="goHome()"
-              >首页</el-button
-            >
+            <el-button type="primary" size="medium" @click="handlePush">首页</el-button>
           </template>
         </el-result>
 
@@ -22,7 +20,7 @@
           subTitle="请重新绑定，将在3秒后跳转到首页"
         >
           <template slot="extra">
-            <el-button type="primary" size="medium">返回</el-button>
+            <el-button type="primary" size="medium" @click="handlePush">返回</el-button>
           </template>
         </el-result>
       </div>
@@ -40,16 +38,35 @@ export default {
       uuid: "",
       loading: true,
       success: "",
+      //定时器
+      timer:null,
+      //3秒后执行
+      count:3,
     };
   },
 
-  //创建的时候自动调用
+  //组件未挂载到DOM，对数据进行初始化
   created() {
     this.uuid = this.$route.params.uuid;
-    this.email(this.uuid);
   },
-  //创建后
-  mounted() {},
+  //DOM已挂载，发送验证异步请求
+  mounted() {
+
+    this.email(this.uuid);
+  
+  },
+  //监听组件渲染变化，促发定时任务
+  updated(){
+    //启动定时器，每隔 1000 毫秒执行一次回调函数
+    this.timer = setInterval(() => {
+      this.count--;
+      if (this.count <= 0) {
+        //执行跳转操作并清除定时器
+        this.$router.push("/");
+        clearInterval(this.timer);
+      }
+    }, 1000); 
+  },
   methods: {
     //获取所有内容
     email(uuid) {
@@ -59,20 +76,16 @@ export default {
           this.success = response.data;
         })
         .catch((response) => {});
-      this.goHome();
-    },
-    goHome() {
-      let count = 3; //赋值多少秒
-      var times = setInterval(() => {
-        count--; //递减
-        if (count <= 0) {
-          // <=0
-          this.$router.push({ path: "/" });
-          clearInterval(times);
-        }
-      }, 1000); //1000毫秒后执行
-    },
-  },
+      }, 
+
+    //立即跳转并清除定时器
+    handlePush() {
+      this.$router.push("/");
+      clearInterval(this.timer);
+    }
+
+},
+    
 };
 </script>
 


### PR DESCRIPTION
1.修复邮箱验证结果弹窗bug、跳转bug
pages/email-validate/_uuid/index.vue页面出现了3个bug

①没有正确返回提示框

通过对后端代码进行标记访问追踪排查，发现了控制层方法被访问了两次；以及使用Apipost接口测试软件发送http请求，后端控制台只显示了控制层方法被访问了一次，这时已经可以大致认为是前端的问题。
通过对前端代码进行标记访问追踪排查，发现浏览器控制台只显示了一次访问。

最终解释：在Nuxt框架中，使用了SSR服务器端渲染技术。当发起页面请求的开始，服务器端会先执行created钩子函数，可以获取数据为后续提供数据给客户端（beforeCreate也会被执行），然后服务器端发送html页面回给浏览器客户端，浏览器会重新执行一遍vue的生命周期函数。

解决方案：将this.email(this.uuid) 放到beforeMount 或者mounted 钩子函数中，推荐放到mounted中，mounted是元素挂载之后，随时更新DOM的行为，此时执行email方法，可以没有页面闪烁，等待根据异步请求结果的变量进行条件渲染。
![image](https://github.com/oddfar/nuxt_campus_example/assets/112877903/ef8445a0-8ba8-464e-8c15-9bab5ea7e966)

②定时任务有时触发无效
解决方案：updated钩子函数监听组件渲染变化，促发定时任务
③按钮立即触发跳转无效
解决方案：设置按钮监听事件回调函数handlePush实现vue路由跳转，并且清除定时器
④v-loading 无自定义指令，代码冗余

2.显示视频海报帧，提高用户体验
components/ContentFile.vue页面

将video标签中的preload属性的值改为metadata
none     当页面加载完，但不预先加载视频（没有视频数据，不能显示第一帧）
auto      一旦页面加载，则开始加载视频 （io消耗大）
metadata 当页面加载后仅加载视频的元数据